### PR TITLE
fix raw mode output

### DIFF
--- a/cmd/1pl/main.go
+++ b/cmd/1pl/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	log.SetOutput(t)
 
-	i := prolog.New(os.Stdin, os.Stdout)
+	i := prolog.New(os.Stdin, t)
 	i.Register1("halt", func(t engine.Term, k func(*engine.Env) *engine.Promise, env *engine.Env) *engine.Promise {
 		restore()
 		return engine.Halt(t, k, env)

--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -2526,6 +2526,8 @@ func (state *State) StreamProperty(streamOrAlias, property Term, k func(*Env) *P
 	return Delay(ks...)
 }
 
+var seek = io.Seeker.Seek
+
 // SetStreamPosition sets the position property of the stream represented by streamOrAlias.
 func (state *State) SetStreamPosition(streamOrAlias, position Term, k func(*Env) *Promise, env *Env) *Promise {
 	s, err := state.stream(streamOrAlias, env)
@@ -2542,7 +2544,7 @@ func (state *State) SetStreamPosition(streamOrAlias, position Term, k func(*Env)
 		return Error(InstantiationError(position))
 	case Integer:
 		if f, ok := s.file.(io.Seeker); ok {
-			if _, err := f.Seek(int64(p), 0); err != nil {
+			if _, err := seek(f, int64(p), 0); err != nil {
 				return Error(SystemError(err))
 			}
 

--- a/engine/stream.go
+++ b/engine/stream.go
@@ -58,7 +58,6 @@ type Stream struct {
 func NewStream(f io.ReadWriteCloser, mode StreamMode, opts ...StreamOption) *Stream {
 	s := Stream{
 		file: f,
-		buf:  bufio.NewReader(f),
 		mode: mode,
 	}
 	if f, ok := f.(*os.File); ok {
@@ -68,6 +67,11 @@ func NewStream(f io.ReadWriteCloser, mode StreamMode, opts ...StreamOption) *Str
 	}
 	for _, opt := range opts {
 		opt(&s)
+	}
+	if a, ok := f.(*rwc); ok && a.r != nil {
+		s.buf = bufio.NewReader(a.r)
+	} else {
+		s.buf = bufio.NewReader(f)
 	}
 	return &s
 }

--- a/engine/stream_test.go
+++ b/engine/stream_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -137,13 +138,13 @@ func TestStream_Close(t *testing.T) {
 		file: &f,
 	}
 	var called bool
-	closeFile = func(file *os.File) error {
+	closeFile = func(file io.Closer) error {
 		assert.Equal(t, &f, file)
 		called = true
 		return nil
 	}
 	defer func() {
-		closeFile = (*os.File).Close
+		closeFile = io.Closer.Close
 	}()
 	assert.NoError(t, s.Close())
 	assert.True(t, called)

--- a/interpreter.go
+++ b/interpreter.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/ichiban/prolog/engine"
@@ -31,7 +31,7 @@ type Interpreter struct {
 }
 
 // New creates a new Prolog interpreter with predefined predicates/operators.
-func New(in, out *os.File) *Interpreter {
+func New(in io.Reader, out io.Writer) *Interpreter {
 	var i Interpreter
 	i.SetUserInput(in)
 	i.SetUserOutput(out)


### PR DESCRIPTION
While reorganizing code related to streams, I ditched arbitrary `io.Reader` / `io.Writer` -backed streams.
It resulted in messed up output in `cmd/1pl/main.go` since it's in raw mode.

This PR fix the problem by reintroducing arbitrary `io.Reader` / `io.Writer` -backed streams.