### PR TITLE
Safer atomics usage

### DIFF
--- a/engine/variable.go
+++ b/engine/variable.go
@@ -14,8 +14,8 @@ var varCounter uint64
 
 // NewVariable creates a new generated variable.
 func NewVariable() Variable {
-	atomic.AddUint64(&varCounter, 1)
-	return Variable(fmt.Sprintf("_%d", varCounter))
+	n := atomic.AddUint64(&varCounter, 1)
+	return Variable(fmt.Sprintf("_%d", n))
 }
 
 var generatedPattern = regexp.MustCompile(`\A_\d+\z`)


### PR DESCRIPTION
I'm not an expert on atomics, but my understanding is that if you're doing atomic writes on an object you need to use atomics for reads too. I changed NewVariable to use `atomic.AddUint64`'s return value instead of accessing the counter variable directly.

Feel free to ignore this if it's wrong. I tried to look up whether accessing global value types non-atomically after atomic writes was safe or not but I couldn't find much, but my gut instinct is that it's probably best avoided 🤔 