### PR TITLE
Fix length

### DIFF
--- a/bootstrap.pl
+++ b/bootstrap.pl
@@ -234,10 +234,6 @@ append([X|L1], L2, [X|L3]) :- append(L1, L2, L3).
 member(X, [X|_]).
 member(X, [_|Xs]) :- member(X, Xs).
 
-:- built_in(length/2).
-length([], 0).
-length([_|Xs], N) :- length(Xs, L), N is L + 1.
-
 :- built_in('.'/2).
 [H|T] :- consult([H|T]).
 

--- a/cmd/1pl/interpreter.go
+++ b/cmd/1pl/interpreter.go
@@ -4,10 +4,12 @@ import (
 	"io"
 
 	"github.com/ichiban/prolog"
+	"github.com/ichiban/prolog/engine"
 )
 
 func New(r io.Reader, w io.Writer) *prolog.Interpreter {
 	i := prolog.New(r, w)
 	i.Register2("call_nth", i.CallNth)
+	i.Register4("skip_max_list", engine.SkipMaxList)
 	return i
 }

--- a/engine/compound.go
+++ b/engine/compound.go
@@ -193,7 +193,13 @@ func (c *Compound) unparseList(emit func(Token), env *Env, opts ...WriteOption) 
 	}
 	if err := iter.Err(); err != nil {
 		emit(Token{Kind: TokenBar, Val: "|"})
-		iter.hare.Unparse(emit, env, opts...)
+
+		suffix := iter.Suffix()
+		if c, ok := suffix.(*Compound); ok && c.Functor == "." && len(c.Args) == 2 {
+			emit(Token{Kind: TokenGraphic, Val: "..."})
+		} else {
+			suffix.Unparse(emit, env, opts...)
+		}
 	}
 	emit(Token{Kind: TokenBracketR, Val: "]"})
 }

--- a/engine/compound_test.go
+++ b/engine/compound_test.go
@@ -115,6 +115,26 @@ func TestCompound_Unparse(t *testing.T) {
 				{Kind: TokenBracketR, Val: "]"},
 			}, ret)
 		})
+
+		t.Run("circular", func(t *testing.T) {
+			v := Variable("L")
+			l := ListRest(v, Atom("a"), Atom("b"))
+			env := NewEnv().Bind(v, l)
+
+			var ret []Token
+			l.Unparse(func(token Token) {
+				ret = append(ret, token)
+			}, env)
+			assert.Equal(t, []Token{
+				{Kind: TokenBracketL, Val: "["},
+				{Kind: TokenIdent, Val: "a"},
+				{Kind: TokenComma, Val: ","},
+				{Kind: TokenIdent, Val: "b"},
+				{Kind: TokenBar, Val: "|"},
+				{Kind: TokenGraphic, Val: "..."},
+				{Kind: TokenBracketR, Val: "]"},
+			}, ret)
+		})
 	})
 
 	t.Run("block", func(t *testing.T) {

--- a/engine/env.go
+++ b/engine/env.go
@@ -177,14 +177,25 @@ func (e *Env) Resolve(t Term) Term {
 
 // Simplify trys to remove as many variables as possible from term t.
 func (e *Env) Simplify(t Term) Term {
-	switch t := e.Resolve(t).(type) {
+	return simplify(t, nil, e)
+}
+
+func simplify(t Term, simplified map[*Compound]*Compound, env *Env) Term {
+	if simplified == nil {
+		simplified = map[*Compound]*Compound{}
+	}
+	switch t := env.Resolve(t).(type) {
 	case *Compound:
+		if c, ok := simplified[t]; ok {
+			return c
+		}
 		c := Compound{
 			Functor: t.Functor,
 			Args:    make([]Term, len(t.Args)),
 		}
-		for i := 0; i < len(c.Args); i++ {
-			c.Args[i] = e.Simplify(t.Args[i])
+		simplified[t] = &c
+		for i, a := range t.Args {
+			c.Args[i] = simplify(a, simplified, env)
 		}
 		return &c
 	default:

--- a/engine/env_test.go
+++ b/engine/env_test.go
@@ -52,3 +52,20 @@ func TestEnv_Lookup(t *testing.T) {
 		})
 	}
 }
+
+func TestEnv_Simplify(t *testing.T) {
+	// L = [a, b|L] ==> [a, b, a, b, ...]
+	l := Variable("L")
+	env := NewEnv().Bind(l, ListRest(l, Atom("a"), Atom("b")))
+	c := env.Simplify(l)
+	iter := ListIterator{List: c, Env: env}
+	assert.True(t, iter.Next())
+	assert.Equal(t, Atom("a"), iter.Current())
+	assert.True(t, iter.Next())
+	assert.Equal(t, Atom("b"), iter.Current())
+	assert.False(t, iter.Next())
+	suffix, ok := iter.Suffix().(*Compound)
+	assert.True(t, ok)
+	assert.Equal(t, Atom("."), suffix.Functor)
+	assert.Len(t, suffix.Args, 2)
+}

--- a/engine/iterator.go
+++ b/engine/iterator.go
@@ -1,25 +1,42 @@
 package engine
 
-// ListIterator is an iterator for a proper list.
+// ListIterator is an iterator for a list.
 type ListIterator struct {
 	List Term
 	Env  *Env
 
-	current, rest Term
-	err           error
-	visited       map[*Compound]struct{}
+	current Term
+	err     error
+
+	// Variables for Brent's cycle detection algorithm
+	tortoise, hare Term
+	power, lam     int
 }
 
 // Next proceeds to the next element of the list and returns true if there's such an element.
 func (i *ListIterator) Next() bool {
-	if i.rest == nil {
-		i.rest = i.List
+	if i.hare == nil {
+		i.hare = i.Env.Resolve(i.List)
 	}
-	if i.visited == nil {
-		i.visited = map[*Compound]struct{}{}
+	if i.power == 0 {
+		i.power = 1
+	}
+	if i.lam == 0 {
+		i.lam = 1
 	}
 
-	switch l := i.Env.Resolve(i.rest).(type) {
+	if i.tortoise == i.hare { // Detected a cycle.
+		i.err = TypeErrorList(i.List, i.Env)
+		return false
+	}
+
+	if i.power == i.lam {
+		i.tortoise = i.hare
+		i.power *= 2
+		i.lam = 0
+	}
+
+	switch l := i.hare.(type) {
 	case Variable:
 		i.err = ErrInstantiation
 		return false
@@ -34,13 +51,8 @@ func (i *ListIterator) Next() bool {
 			return false
 		}
 
-		if _, ok := i.visited[l]; ok {
-			i.err = TypeErrorList(i.List, i.Env)
-			return false
-		}
-		i.visited[l] = struct{}{}
-
-		i.current, i.rest = l.Args[0], l.Args[1]
+		i.current, i.hare = l.Args[0], i.Env.Resolve(l.Args[1])
+		i.lam += 1
 		return true
 	default:
 		i.err = TypeErrorList(i.List, i.Env)

--- a/engine/iterator.go
+++ b/engine/iterator.go
@@ -71,6 +71,9 @@ func (i *ListIterator) Err() error {
 }
 
 func (i *ListIterator) Suffix() Term {
+	if i.hare == nil {
+		return i.List
+	}
 	return i.hare
 }
 

--- a/engine/iterator_test.go
+++ b/engine/iterator_test.go
@@ -62,12 +62,17 @@ func TestListIterator_Next(t *testing.T) {
 
 		t.Run("circular list", func(t *testing.T) {
 			l := Variable("L")
-			env := NewEnv().Bind(l, ListRest(l, Atom("a")))
-			iter := ListIterator{List: l, Env: env}
-			assert.True(t, iter.Next())
-			assert.Equal(t, Atom("a"), iter.Current())
-			assert.False(t, iter.Next())
-			assert.Equal(t, TypeErrorList(l, env), iter.Err())
+			const max = 500
+			elems := make([]Term, 0, max)
+			for i := 0; i < max; i++ {
+				elems = append(elems, Atom("a"))
+				env := NewEnv().Bind(l, ListRest(l, elems...))
+				iter := ListIterator{List: l, Env: env}
+				for iter.Next() {
+					assert.Equal(t, Atom("a"), iter.Current())
+				}
+				assert.Equal(t, TypeErrorList(l, env), iter.Err())
+			}
 		})
 	})
 }

--- a/engine/iterator_test.go
+++ b/engine/iterator_test.go
@@ -77,6 +77,18 @@ func TestListIterator_Next(t *testing.T) {
 	})
 }
 
+func TestListIterator_Suffix(t *testing.T) {
+	iter := ListIterator{List: List(Atom("a"), Atom("b"), Atom("c"))}
+	assert.Equal(t, List(Atom("a"), Atom("b"), Atom("c")), iter.Suffix())
+	assert.True(t, iter.Next())
+	assert.Equal(t, List(Atom("b"), Atom("c")), iter.Suffix())
+	assert.True(t, iter.Next())
+	assert.Equal(t, List(Atom("c")), iter.Suffix())
+	assert.True(t, iter.Next())
+	assert.Equal(t, List(), iter.Suffix())
+	assert.False(t, iter.Next())
+}
+
 func TestSeqIterator_Next(t *testing.T) {
 	t.Run("sequence", func(t *testing.T) {
 		iter := SeqIterator{Seq: Seq(",", Atom("a"), Atom("b"), Atom("c"))}

--- a/engine/number.go
+++ b/engine/number.go
@@ -2,6 +2,11 @@ package engine
 
 import "math"
 
+var (
+	maxInt = Integer(math.MaxInt64)
+	minInt = Integer(math.MinInt64)
+)
+
 // DefaultEvaluableFunctors is a EvaluableFunctors with builtin functions.
 var DefaultEvaluableFunctors = EvaluableFunctors{
 	Constant: map[Atom]Number{
@@ -934,7 +939,7 @@ func IntegerPower(x, y Number) (Number, error) {
 		case 0:
 			return nil, ErrUndefined
 		case 1, -1:
-			vy, err := negI(vy) // y can be math.MinInt64
+			vy, err := negI(vy) // y can be minInt
 			if err != nil {
 				return nil, err
 			}
@@ -1188,7 +1193,7 @@ func floatFtoF(x Float) Float {
 
 func floorFtoI(x Float) (Integer, error) {
 	f := math.Floor(float64(x))
-	if f > math.MaxInt64 || f < math.MinInt64 {
+	if f > float64(maxInt) || f < float64(minInt) {
 		return 0, ErrIntOverflow
 	}
 	return Integer(f), nil
@@ -1196,7 +1201,7 @@ func floorFtoI(x Float) (Integer, error) {
 
 func truncateFtoI(x Float) (Integer, error) {
 	t := math.Trunc(float64(x))
-	if t > math.MaxInt64 || t < math.MinInt64 {
+	if t > float64(maxInt) || t < float64(minInt) {
 		return 0, ErrIntOverflow
 	}
 	return Integer(t), nil
@@ -1204,7 +1209,7 @@ func truncateFtoI(x Float) (Integer, error) {
 
 func roundFtoI(x Float) (Integer, error) {
 	r := math.Round(float64(x))
-	if r > math.MaxInt64 || r < math.MinInt64 {
+	if r > float64(maxInt) || r < float64(minInt) {
 		return 0, ErrIntOverflow
 	}
 	return Integer(r), nil
@@ -1212,7 +1217,7 @@ func roundFtoI(x Float) (Integer, error) {
 
 func ceilingFtoI(x Float) (Integer, error) {
 	c := math.Ceil(float64(x))
-	if c > math.MaxInt64 || c < math.MinInt64 {
+	if c > float64(maxInt) || c < float64(minInt) {
 		return 0, ErrIntOverflow
 	}
 	return Integer(c), nil
@@ -1222,9 +1227,9 @@ func ceilingFtoI(x Float) (Integer, error) {
 
 func addI(x, y Integer) (Integer, error) {
 	switch {
-	case y > 0 && x > math.MaxInt64-y:
+	case y > 0 && x > maxInt-y:
 		return 0, ErrIntOverflow
-	case y < 0 && x < math.MinInt64-y:
+	case y < 0 && x < minInt-y:
 		return 0, ErrIntOverflow
 	default:
 		return x + y, nil
@@ -1233,9 +1238,9 @@ func addI(x, y Integer) (Integer, error) {
 
 func subI(x, y Integer) (Integer, error) {
 	switch {
-	case y < 0 && x > math.MaxInt64+y:
+	case y < 0 && x > maxInt+y:
 		return 0, ErrIntOverflow
-	case y > 0 && x < math.MinInt64+y:
+	case y > 0 && x < minInt+y:
 		return 0, ErrIntOverflow
 	default:
 		return x - y, nil
@@ -1244,9 +1249,9 @@ func subI(x, y Integer) (Integer, error) {
 
 func mulI(x, y Integer) (Integer, error) {
 	switch {
-	case x == -1 && y == math.MinInt64:
+	case x == -1 && y == minInt:
 		return 0, ErrIntOverflow
-	case x == math.MinInt64 && y == -1:
+	case x == minInt && y == -1:
 		return 0, ErrIntOverflow
 	case y == 0:
 		return 0, nil
@@ -1263,7 +1268,7 @@ func intDivI(x, y Integer) (Integer, error) {
 	switch {
 	case y == 0:
 		return 0, ErrZeroDivisor
-	case x == math.MinInt64 && y == -1:
+	case x == minInt && y == -1:
 		// Two's complement special case
 		return 0, ErrIntOverflow
 	default:
@@ -1287,7 +1292,7 @@ func modI(x, y Integer) (Integer, error) {
 
 func negI(x Integer) (Integer, error) {
 	// Two's complement special case
-	if x == math.MinInt64 {
+	if x == minInt {
 		return 0, ErrIntOverflow
 	}
 	return -x, nil
@@ -1295,7 +1300,7 @@ func negI(x Integer) (Integer, error) {
 
 func absI(x Integer) (Integer, error) {
 	switch {
-	case x == math.MinInt64:
+	case x == minInt:
 		return 0, ErrIntOverflow
 	case x < 0:
 		return -x, nil
@@ -1321,7 +1326,7 @@ func posI(x Integer) (Integer, error) {
 
 func intFloorDivI(x, y Integer) (Integer, error) {
 	switch {
-	case x == math.MinInt64 && y == -1:
+	case x == minInt && y == -1:
 		return 0, ErrIntOverflow
 	case y == 0:
 		return 0, ErrZeroDivisor

--- a/engine/parser.go
+++ b/engine/parser.go
@@ -287,7 +287,7 @@ func (p *Parser) number() (Term, error) {
 	}
 
 	if sign != "" {
-		return Atom(sign), nil
+		return sign, nil
 	}
 
 	return nil, errNotANumber

--- a/engine/promise.go
+++ b/engine/promise.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 )
 
 // Promise is a delayed execution that results in (bool, error). The zero value for Promise is equivalent to Bool(false).
@@ -72,7 +71,7 @@ func (p *Promise) Force(ctx context.Context) (bool, error) {
 	for len(stack) > 0 {
 		select {
 		case <-ctx.Done():
-			return false, errors.New("canceled")
+			return false, context.Canceled
 		default:
 			p := stack.pop()
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -111,6 +111,7 @@ func New(in io.Reader, out io.Writer) *Interpreter {
 	i.Register3("nth0", engine.Nth0)
 	i.Register3("nth1", engine.Nth1)
 	i.Register2("succ", engine.Succ)
+	i.Register2("length", engine.Length)
 	if err := i.Exec(bootstrap); err != nil {
 		panic(err)
 	}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -1,14 +1,11 @@
 package prolog
 
 import (
-	"context"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/ichiban/prolog/engine"
 )
@@ -126,16 +123,12 @@ func TestNew(t *testing.T) {
 		assert.NoError(t, p.QuerySolution(`catch(length([],-_), error(type_error(integer,-_), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch(length([a],-_), error(type_error(integer,-_), _), true).`).Err())
 		*/
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		assert.Equal(t, context.Canceled, p.QuerySolutionContext(ctx, `length([a,b|X],X).`).Err())
-		cancel()
-		ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-		assert.Equal(t, context.Canceled, p.QuerySolutionContext(ctx, `length(L,L).`).Err())
-		cancel()
+		assert.NoError(t, p.QuerySolution(`catch(length([a,b|X],X), error(resource_error(finite_memory), _), true).`).Err())
+		assert.NoError(t, p.QuerySolution(`catch(length(L,L), error(resource_error(finite_memory), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch((L = [_|_], length(L,L)), error(type_error(integer,[_|_]), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch((L = [_], length(L,L)), error(type_error(integer,[_]), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch((L = [1], length(L,L)), error(type_error(integer,[1]), _), true).`).Err())
-		assert.Equal(t, ErrNoSolutions, p.QuerySolution(`L = [a|L], length(L,N).`).Err())
+		assert.NoError(t, p.QuerySolution(`catch((L = [a|L], length(L,N)), error(resource_error(finite_memory), _), true).`).Err())
 		assert.Equal(t, ErrNoSolutions, p.QuerySolution(`L = [a|L], length(L,0).`).Err())
 		assert.Equal(t, ErrNoSolutions, p.QuerySolution(`L = [a|L], length(L,7).`).Err())
 		/* This library doesn't implement freeze/2

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -119,10 +119,8 @@ func TestNew(t *testing.T) {
 		assert.NoError(t, p.QuerySolution(`catch(length(L,1.0e99), error(type_error(integer,1.0e99), _), true).`).Err())
 		assert.Equal(t, ErrNoSolutions, p.QuerySolution(`N is 2^52, length([], N).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch(length([],0+0), error(type_error(integer,0+0), _), true).`).Err())
-		/* TODO: fix handling of minus https://github.com/ichiban/prolog/issues/210
 		assert.NoError(t, p.QuerySolution(`catch(length([],-_), error(type_error(integer,-_), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch(length([a],-_), error(type_error(integer,-_), _), true).`).Err())
-		*/
 		assert.NoError(t, p.QuerySolution(`catch(length([a,b|X],X), error(resource_error(finite_memory), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch(length(L,L), error(resource_error(finite_memory), _), true).`).Err())
 		assert.NoError(t, p.QuerySolution(`catch((L = [_|_], length(L,L)), error(type_error(integer,[_|_]), _), true).`).Err())


### PR DESCRIPTION
#191 

This PR re-implements `length/2` as described in http://www.complang.tuwien.ac.at/ulrich/iso-prolog/prologue#length

Also, improved cycle detection with Brent's cycle detection algorithm.