### PR TITLE
refactor: less memory allocation in parser.go

### DIFF
--- a/engine/atom.go
+++ b/engine/atom.go
@@ -111,14 +111,6 @@ func quotedIdentEscape(s string) string {
 	}
 }
 
-func quoteSlice(ss []string) []string {
-	ret := make([]string, len(ss))
-	for i, s := range ss {
-		ret[i] = quote(s)
-	}
-	return ret
-}
-
 func unquote(s string) string {
 	return quotedIdentEscapePattern.ReplaceAllStringFunc(s[1:len(s)-1], quotedIdentUnescape)
 }


### PR DESCRIPTION
#218 This PR reduces memory consumption in the parser.

It slims down memory allocation of the tests for `1pl` from 24581.51kB to 3073.43kB.

<details>
<summary> before: 24581.51kB total</summary>

```console
$ git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.
$ go test -memprofile mem.prof github.com/ichiban/prolog/cmd/1pl
ok  	github.com/ichiban/prolog/cmd/1pl	0.173s
$ go tool pprof --text 1pl.test mem.prof 
File: 1pl.test
Type: alloc_space
Time: May 8, 2022 at 7:35pm (JST)
Showing nodes accounting for 24581.51kB, 100% of 24581.51kB total
      flat  flat%   sum%        cum   cum%
16897.29kB 68.74% 68.74% 16897.29kB 68.74%  github.com/ichiban/prolog/engine.(*Parser).expectationError (inline)
 1537.69kB  6.26% 75.00%  1537.69kB  6.26%  runtime.allocm
 1536.02kB  6.25% 81.24%  1536.02kB  6.25%  errors.New (inline)
 1536.02kB  6.25% 87.49%  1536.02kB  6.25%  github.com/ichiban/prolog/engine.quoteSlice
 1024.41kB  4.17% 91.66%  1024.41kB  4.17%  runtime.malg
     514kB  2.09% 93.75%      514kB  2.09%  bufio.NewReaderSize (inline)
  512.04kB  2.08% 95.83%   512.04kB  2.08%  github.com/ichiban/prolog/engine.Delay (inline)
  512.03kB  2.08% 97.92%   512.03kB  2.08%  github.com/ichiban/prolog/engine.(*clause).xrOffset
  512.01kB  2.08%   100% 16897.10kB 68.74%  github.com/ichiban/prolog/engine.(*Parser).acceptOp
         0     0%   100%      514kB  2.09%  bufio.NewReader (inline)
         0     0%   100% 19457.29kB 79.15%  github.com/ichiban/prolog.(*Interpreter).Exec (inline)
         0     0%   100% 19457.29kB 79.15%  github.com/ichiban/prolog.(*Interpreter).ExecContext
         0     0%   100%  1026.01kB  4.17%  github.com/ichiban/prolog.(*Interpreter).Query (inline)
         0     0%   100%  2050.09kB  8.34%  github.com/ichiban/prolog.(*Interpreter).QueryContext
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog.(*Interpreter).QueryContext.func1
         0     0%   100%  1024.08kB  4.17%  github.com/ichiban/prolog.(*Interpreter).QuerySolution (inline)
         0     0%   100%  1024.08kB  4.17%  github.com/ichiban/prolog.(*Interpreter).QuerySolutionContext
         0     0%   100% 19457.29kB 79.15%  github.com/ichiban/prolog.New
         0     0%   100% 19457.29kB 79.15%  github.com/ichiban/prolog/cmd/1pl.New
         0     0%   100% 21507.38kB 87.49%  github.com/ichiban/prolog/cmd/1pl.TestNew.func1
         0     0%   100% 20481.34kB 83.32%  github.com/ichiban/prolog/engine.(*Parser).Term
         0     0%   100% 16897.29kB 68.74%  github.com/ichiban/prolog/engine.(*Parser).accept
         0     0%   100% 17921.21kB 72.91%  github.com/ichiban/prolog/engine.(*Parser).acceptAtom
         0     0%   100%  2048.12kB  8.33%  github.com/ichiban/prolog/engine.(*Parser).acceptPrefix
         0     0%   100% 12288.81kB 49.99%  github.com/ichiban/prolog/engine.(*Parser).atomOrCompound
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog/engine.(*Parser).block
         0     0%   100% 16897.29kB 68.74%  github.com/ichiban/prolog/engine.(*Parser).expect
         0     0%   100% 19969.30kB 81.24%  github.com/ichiban/prolog/engine.(*Parser).expr
         0     0%   100% 13824.93kB 56.24%  github.com/ichiban/prolog/engine.(*Parser).lhs
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog/engine.(*Parser).list
         0     0%   100%  3072.23kB 12.50%  github.com/ichiban/prolog/engine.(*Parser).paren
         0     0%   100%  5632.40kB 22.91%  github.com/ichiban/prolog/engine.(*Parser).prefix
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog/engine.(*Promise).Force
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog/engine.(*Promise).child
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.(*State).Call
         0     0%   100%      514kB  2.09%  github.com/ichiban/prolog/engine.(*State).Parser
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.(*clause).compileArg
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.(*clause).compileBody
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.(*clause).compilePred
         0     0%   100%   512.04kB  2.08%  github.com/ichiban/prolog/engine.clauses.Call.func5
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.compile
         0     0%   100%   512.03kB  2.08%  github.com/ichiban/prolog/engine.compileClause
         0     0%   100%  1025.12kB  4.17%  runtime.mcall
         0     0%   100%   512.56kB  2.09%  runtime.mstart
         0     0%   100%   512.56kB  2.09%  runtime.mstart0
         0     0%   100%   512.56kB  2.09%  runtime.mstart1
         0     0%   100%  1537.69kB  6.26%  runtime.newm
         0     0%   100%  1024.41kB  4.17%  runtime.newproc.func1
         0     0%   100%  1024.41kB  4.17%  runtime.newproc1
         0     0%   100%  1025.12kB  4.17%  runtime.park_m
         0     0%   100%  1537.69kB  6.26%  runtime.resetspinning
         0     0%   100%  1537.69kB  6.26%  runtime.schedule
         0     0%   100%  1537.69kB  6.26%  runtime.startm
         0     0%   100%  1024.41kB  4.17%  runtime.systemstack
         0     0%   100%  1537.69kB  6.26%  runtime.wakep
         0     0%   100% 21507.38kB 87.49%  testing.tRunner
```

</details>


<details>
<summary>after: 3073.43kB total</summary>

```console
$ git checkout refactor-parser-less-alloc
Switched to branch 'refactor-parser-less-alloc'
$ go test -memprofile mem.prof github.com/ichiban/prolog/cmd/1pl
ok  	github.com/ichiban/prolog/cmd/1pl	0.301s
$ go tool pprof --text 1pl.test mem.prof 
File: 1pl.test
Type: alloc_space
Time: May 8, 2022 at 7:37pm (JST)
Showing nodes accounting for 3073.43kB, 100% of 3073.43kB total
      flat  flat%   sum%        cum   cum%
 1025.12kB 33.35% 33.35%  1025.12kB 33.35%  runtime.allocm
  512.20kB 16.67% 50.02%   512.20kB 16.67%  runtime.malg
  512.04kB 16.66% 66.68%   512.04kB 16.66%  github.com/ichiban/prolog/engine.Bool (inline)
  512.03kB 16.66% 83.34%  1024.06kB 33.32%  github.com/ichiban/prolog/engine.(*Env).Bind (inline)
  512.03kB 16.66%   100%   512.03kB 16.66%  github.com/ichiban/prolog/engine.(*Env).insert
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog.(*Interpreter).Exec (inline)
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog.(*Interpreter).ExecContext
         0     0%   100%  1024.07kB 33.32%  github.com/ichiban/prolog.(*Interpreter).QueryContext.func1
         0     0%   100%   512.04kB 16.66%  github.com/ichiban/prolog.(*Interpreter).QueryContext.func1.1
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog.New
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/cmd/1pl.New
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/cmd/1pl.TestNew.func1
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/engine.(*Compound).Unify
         0     0%   100%  1536.10kB 49.98%  github.com/ichiban/prolog/engine.(*Promise).Force
         0     0%   100%  1536.10kB 49.98%  github.com/ichiban/prolog/engine.(*Promise).child
         0     0%   100%   512.04kB 16.66%  github.com/ichiban/prolog/engine.(*VM).Arrive.func2
         0     0%   100%  1536.10kB 49.98%  github.com/ichiban/prolog/engine.(*VM).exec
         0     0%   100%  1024.07kB 33.32%  github.com/ichiban/prolog/engine.(*VM).execCall.func1.1
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/engine.(*VM).execConst
         0     0%   100%  1024.07kB 33.32%  github.com/ichiban/prolog/engine.(*VM).execExit
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/engine.(*VM).execFunctor
         0     0%   100%   512.03kB 16.66%  github.com/ichiban/prolog/engine.Functor
         0     0%   100%  1024.07kB 33.32%  github.com/ichiban/prolog/engine.Unify
         0     0%   100%  1024.06kB 33.32%  github.com/ichiban/prolog/engine.Variable.Unify
         0     0%   100%  1024.06kB 33.32%  github.com/ichiban/prolog/engine.clauses.Call.func5.1
         0     0%   100%  1024.07kB 33.32%  github.com/ichiban/prolog/engine.clauses.Call.func5.1.1
         0     0%   100%   512.04kB 16.66%  github.com/ichiban/prolog/engine.predicate2.Call
         0     0%   100%   512.56kB 16.68%  runtime.mcall
         0     0%   100%   512.56kB 16.68%  runtime.mstart
         0     0%   100%   512.56kB 16.68%  runtime.mstart0
         0     0%   100%   512.56kB 16.68%  runtime.mstart1
         0     0%   100%  1025.12kB 33.35%  runtime.newm
         0     0%   100%   512.20kB 16.67%  runtime.newproc.func1
         0     0%   100%   512.20kB 16.67%  runtime.newproc1
         0     0%   100%   512.56kB 16.68%  runtime.park_m
         0     0%   100%  1025.12kB 33.35%  runtime.resetspinning
         0     0%   100%  1025.12kB 33.35%  runtime.schedule
         0     0%   100%  1025.12kB 33.35%  runtime.startm
         0     0%   100%   512.20kB 16.67%  runtime.systemstack
         0     0%   100%  1025.12kB 33.35%  runtime.wakep
         0     0%   100%   512.03kB 16.66%  testing.tRunner
```

</details>