### PR TITLE
fixed parsing of arg '[]' and '{}'

### DIFF
--- a/engine/parser.go
+++ b/engine/parser.go
@@ -761,11 +761,10 @@ func (p *Parser) arg() (Term, error) {
 				p.backup()
 			}
 		}
-		switch arg {
-		case "[]", "{}":
-			p.backup()
-		}
 		p.backup()
+		if p.current().Kind == TokenCloseList || p.current().Kind == TokenCloseCurly {
+			p.backup() // Unquoted [] or {} consist of 2 tokens.
+		}
 	}
 
 	return p.term(999)

--- a/engine/parser_test.go
+++ b/engine/parser_test.go
@@ -131,6 +131,10 @@ func TestParser_Term(t *testing.T) {
 		{input: `"\'".`, opts: []parserOption{withDoubleQuotes(doubleQuotesAtom)}, term: Atom(`'`)},
 		{input: `"\"".`, opts: []parserOption{withDoubleQuotes(doubleQuotesAtom)}, term: Atom(`"`)},
 		{input: "\"\\`\".", opts: []parserOption{withDoubleQuotes(doubleQuotesAtom)}, term: Atom("`")},
+
+		// https://github.com/ichiban/prolog/issues/219#issuecomment-1200489336
+		{input: `write('[]').`, term: &Compound{Functor: `write`, Args: []Term{Atom(`[]`)}}},
+		{input: `write('{}').`, term: &Compound{Functor: `write`, Args: []Term{Atom(`{}`)}}},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
https://github.com/ichiban/prolog/issues/219#issuecomment-1200489336