### PR TITLE
optimize one-char atoms

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -1541,7 +1541,7 @@ func CharCode(char, code Term, k func(*Env) *Promise, env *Env) *Promise {
 			}
 
 			return Delay(func(context.Context) *Promise {
-				return Unify(ch, NewAtom(string(r)), k, env)
+				return Unify(ch, Atom(r), k, env)
 			})
 		default:
 			return Error(TypeError(ValidTypeInteger, code, env))
@@ -1785,7 +1785,7 @@ func (state *State) GetChar(streamOrAlias, char Term, k func(*Env) *Promise, env
 			return Error(RepresentationError(FlagCharacter, env))
 		}
 
-		return Unify(char, NewAtom(string(r)), k, env)
+		return Unify(char, Atom(r), k, env)
 	case io.EOF:
 		return Unify(char, atomEndOfFile, k, env)
 	case errWrongIOMode:
@@ -1865,7 +1865,7 @@ func (state *State) PeekChar(streamOrAlias, char Term, k func(*Env) *Promise, en
 			return Error(RepresentationError(FlagCharacter, env))
 		}
 
-		return Unify(char, NewAtom(string(r)), k, env)
+		return Unify(char, Atom(r), k, env)
 	case io.EOF:
 		return Unify(char, atomEndOfFile, k, env)
 	case errWrongIOMode:
@@ -2240,7 +2240,7 @@ func numberCharsWrite(num, chars Term, k func(*Env) *Promise, env *Env) *Promise
 
 		cs := make([]Term, len(rs))
 		for i, r := range rs {
-			cs[i] = NewAtom(string(r))
+			cs[i] = Atom(r)
 		}
 		return Unify(chars, List(cs...), k, env)
 	default:
@@ -2470,7 +2470,7 @@ func (state *State) CurrentCharConversion(inChar, outChar Term, k func(*Env) *Pr
 	if c1, ok := env.Resolve(inChar).(Atom); ok {
 		r := []rune(c1.String())
 		if r, ok := state.charConversions[r[0]]; ok {
-			return Unify(outChar, NewAtom(string(r)), k, env)
+			return Unify(outChar, Atom(r), k, env)
 		}
 		return Unify(outChar, c1, k, env)
 	}
@@ -2485,7 +2485,7 @@ func (state *State) CurrentCharConversion(inChar, outChar Term, k func(*Env) *Pr
 		}
 
 		ks[i] = func(context.Context) *Promise {
-			return Unify(pattern, tuple(NewAtom(string(r)), NewAtom(string(cr))), k, env)
+			return Unify(pattern, tuple(Atom(r), Atom(cr)), k, env)
 		}
 	}
 	return Delay(ks...)

--- a/engine/compound.go
+++ b/engine/compound.go
@@ -183,7 +183,7 @@ func Pair(k, v Term) Term {
 }
 
 func tuple(args ...Term) Term {
-	return atomEmpty.Apply(args...)
+	return Atom(0).Apply(args...)
 }
 
 type charList string
@@ -197,11 +197,11 @@ func (c charList) Arity() int {
 }
 
 func (c charList) Arg(n int) Term {
-	_, i := utf8.DecodeRuneInString(string(c))
+	r, i := utf8.DecodeRuneInString(string(c))
 	var t Term
 	switch n {
 	case 0:
-		t = NewAtom(string(c[:i]))
+		t = Atom(r)
 	case 1:
 		if i == len(c) {
 			t = atomEmptyList
@@ -231,13 +231,12 @@ func (c codeList) Arity() int {
 }
 
 func (c codeList) Arg(n int) Term {
+	r, i := utf8.DecodeRuneInString(string(c))
 	var t Term
 	switch n {
 	case 0:
-		r, _ := utf8.DecodeRuneInString(string(c))
 		t = Integer(r)
 	case 1:
-		_, i := utf8.DecodeRuneInString(string(c))
 		if i == len(c) {
 			t = atomEmptyList
 		} else {

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -322,7 +322,6 @@ func TestNewProcedureIndicator(t *testing.T) {
 }
 
 func TestProcedureIndicator_String(t *testing.T) {
-	assert.Equal(t, `''/0`, ProcedureIndicator{}.String())
 	assert.Equal(t, `foo/2`, ProcedureIndicator{Name: NewAtom("foo"), Arity: 2}.String())
 }
 


### PR DESCRIPTION
We don't have to intern atoms when they're one-char atoms.