### PR TITLE
efficient renamed copy for partials

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -396,6 +396,13 @@ func renamedCopy(t Term, copied map[termID]Term, env *Env) Term {
 			l[i] = renamedCopy(t[i], copied, env)
 		}
 		return l
+	case *partial:
+		var p partial
+		copied[id(t)] = &p
+		p.Compound = renamedCopy(t.Compound, copied, env).(Compound)
+		tail := renamedCopy(*t.tail, copied, env)
+		p.tail = &tail
+		return &p
 	case Compound:
 		c := compound{
 			functor: t.Functor(),
@@ -2849,9 +2856,9 @@ func Append(vm *VM, xs, ys, zs Term, k Cont, env *Env) *Promise {
 		for iter.Next() {
 		}
 		if err := iter.Err(); err == nil {
-			return Unify(vm, zs, partial{
+			return Unify(vm, zs, &partial{
 				Compound: xs,
-				tail:     ys,
+				tail:     &ys,
 			}, k, env)
 		}
 	}

--- a/engine/clause.go
+++ b/engine/clause.go
@@ -141,10 +141,10 @@ func (c *clause) compileArg(a Term, env *Env) {
 			c.compileArg(arg, env)
 		}
 		c.bytecode = append(c.bytecode, instruction{opcode: opPop})
-	case partial:
+	case *partial:
 		prefix := a.Compound.(list)
 		c.bytecode = append(c.bytecode, instruction{opcode: opPartial, operand: c.xrOffset(Integer(len(prefix)))})
-		c.compileArg(a.tail, env)
+		c.compileArg(*a.tail, env)
 		for _, arg := range prefix {
 			c.compileArg(arg, env)
 		}

--- a/engine/compound.go
+++ b/engine/compound.go
@@ -102,33 +102,33 @@ func List(ts ...Term) Term {
 
 type partial struct {
 	Compound
-	tail Term
+	tail *Term
 }
 
-func (p partial) termID() termID { // The underlying compound might not be comparable.
+func (p *partial) termID() termID { // The underlying compound might not be comparable.
 	type partialID struct {
 		prefixID, tailID termID
 	}
 	return partialID{
 		prefixID: id(p.Compound),
-		tailID:   id(p.tail),
+		tailID:   p.tail,
 	}
 }
 
-func (p partial) Arg(n int) Term {
+func (p *partial) Arg(n int) Term {
 	t := p.Compound.Arg(n)
 	if c := p.Compound; c.Functor() == atomDot && c.Arity() == 2 && n == 1 {
 		if t == atomEmptyList {
-			t = p.tail
+			t = *p.tail
 		} else {
-			t = partial{Compound: t.(Compound), tail: p.tail}
+			t = &partial{Compound: t.(Compound), tail: p.tail}
 		}
 	}
 	return t
 }
 
-func (p partial) GoString() string {
-	return fmt.Sprintf(`engine.partial{Compound:%#v, tail:%#v}`, p.Compound, p.tail)
+func (p *partial) GoString() string {
+	return fmt.Sprintf(`engine.partial{Compound:%#v, tail:%#v}`, p.Compound, *p.tail)
 }
 
 // PartialList returns a list of ts followed by tail.
@@ -136,9 +136,9 @@ func PartialList(tail Term, ts ...Term) Term {
 	if len(ts) == 0 {
 		return tail
 	}
-	return partial{
+	return &partial{
 		Compound: list(ts),
-		tail:     tail,
+		tail:     &tail,
 	}
 }
 

--- a/engine/compound_test.go
+++ b/engine/compound_test.go
@@ -42,7 +42,7 @@ func TestList(t *testing.T) {
 }
 
 func TestPartialList(t *testing.T) {
-	x := NewVariable()
+	x := Term(NewVariable())
 
 	tests := []struct {
 		title string
@@ -51,7 +51,7 @@ func TestPartialList(t *testing.T) {
 		list  Term
 	}{
 		{title: "empty", rest: x, elems: nil, list: x},
-		{title: "non-empty", rest: x, elems: []Term{NewAtom("a"), NewAtom("b")}, list: partial{Compound: list{NewAtom("a"), NewAtom("b")}, tail: x}},
+		{title: "non-empty", rest: x, elems: []Term{NewAtom("a"), NewAtom("b")}, list: &partial{Compound: list{NewAtom("a"), NewAtom("b")}, tail: &x}},
 	}
 
 	for _, tt := range tests {

--- a/engine/env.go
+++ b/engine/env.go
@@ -218,6 +218,13 @@ func simplify(t Term, simplified map[termID]Compound, env *Env) Term {
 			l[i] = simplify(e, simplified, env)
 		}
 		return l
+	case *partial:
+		var p partial
+		simplified[id(t)] = &p
+		p.Compound = simplify(t.Compound, simplified, env).(Compound)
+		tail := simplify(*t.tail, simplified, env)
+		p.tail = &tail
+		return &p
 	case Compound:
 		c := compound{
 			functor: t.Functor(),

--- a/engine/env_test.go
+++ b/engine/env_test.go
@@ -66,7 +66,7 @@ func TestEnv_Simplify(t *testing.T) {
 	assert.True(t, iter.Next())
 	assert.Equal(t, NewAtom("b"), iter.Current())
 	assert.False(t, iter.Next())
-	suffix, ok := iter.Suffix().(Compound)
+	suffix, ok := iter.Suffix().(*partial)
 	assert.True(t, ok)
 	assert.Equal(t, atomDot, suffix.Functor())
 	assert.Equal(t, 2, suffix.Arity())


### PR DESCRIPTION
Renamed copy of `engine.partial` was a bit tricky when it's a cyclic term and it used to fallback to `*engine.compound`.

This PR modifies `engine.partial` a bit so that we can get an efficient renamed copy of `*engine.partial`.

```prolog
$ $(go env GOPATH)/bin/1pl inriasuite.pl
Top level for ichiban/prolog v0.14.0
This is for testing purposes only!
See https://github.com/ichiban/prolog for more details.
Type Ctrl-C or 'halt.' to exit.
?- copy_term([a, b|X], C), go_string(C, S).
X = _409,
C = [a,b|_420],
S = '&engine.compound{functor:".", args:[]engine.Term{"a", &engine.compound{functor:".", args:[]engine.Term{"b", 420}}}}'
```

```prolog
$ go run cmd/1pl/main.go cmd/1pl/interpreter.go 
Top level for ichiban/prolog 
This is for testing purposes only!
See https://github.com/ichiban/prolog for more details.
Type Ctrl-C or 'halt.' to exit.
?- copy_term([a, b|X], C), go_string(C, S).
X = _270,
C = [a,b|_281],
S = 'engine.partial{Compound:engine.list{"a", "b"}, tail:281}'
```