### PR TITLE
define Scanner interface

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -169,7 +169,7 @@ func SubsumesTerm(_ *VM, general, specific Term, k Cont, env *Env) *Promise {
 		return Bool(false)
 	}
 
-	if d := env.compare(theta.Simplify(general), specific); d != 0 {
+	if d := env.compare(theta.simplify(general), specific); d != 0 {
 		return Bool(false)
 	}
 
@@ -1502,9 +1502,7 @@ func CharCode(vm *VM, char, code Term, k Cont, env *Env) *Promise {
 				return Error(representationError(flagCharacterCode, env))
 			}
 
-			return Delay(func(context.Context) *Promise {
-				return Unify(vm, ch, Atom(r), k, env)
-			})
+			return Unify(vm, ch, Atom(r), k, env)
 		default:
 			return Error(typeError(validTypeInteger, code, env))
 		}
@@ -1521,9 +1519,7 @@ func CharCode(vm *VM, char, code Term, k Cont, env *Env) *Promise {
 			return Error(typeError(validTypeCharacter, ch, env))
 		}
 
-		return Delay(func(context.Context) *Promise {
-			return Unify(vm, code, Integer(rs[0]), k, env)
-		})
+		return Unify(vm, code, Integer(rs[0]), k, env)
 	default:
 		return Error(typeError(validTypeCharacter, ch, env))
 	}
@@ -2618,7 +2614,7 @@ func expand(vm *VM, term Term, env *Env) (Term, error) {
 		var ret Term
 		v := NewVariable()
 		ok, err := Call(vm, atomTermExpansion.Apply(term, v), func(env *Env) *Promise {
-			ret = env.Simplify(v)
+			ret = env.simplify(v)
 			return Bool(true)
 		}, env).Force(context.Background())
 		if err != nil {

--- a/engine/clause.go
+++ b/engine/clause.go
@@ -61,7 +61,7 @@ func compile(t Term, env *Env) (clauses, error) {
 	}
 
 	c, err := compileClause(t, nil, env)
-	c.raw = env.Simplify(t)
+	c.raw = env.simplify(t)
 	return []clause{c}, err
 }
 

--- a/engine/env.go
+++ b/engine/env.go
@@ -195,8 +195,8 @@ func (e *Env) Resolve(t Term) Term {
 	return nil
 }
 
-// Simplify trys to remove as many variables as possible from term t.
-func (e *Env) Simplify(t Term) Term {
+// simplify trys to remove as many variables as possible from term t.
+func (e *Env) simplify(t Term) Term {
 	return simplify(t, nil, e)
 }
 

--- a/engine/env_test.go
+++ b/engine/env_test.go
@@ -59,7 +59,7 @@ func TestEnv_Simplify(t *testing.T) {
 	l := NewVariable()
 	p := PartialList(l, NewAtom("a"), NewAtom("b"))
 	env := NewEnv().bind(l, p)
-	c := env.Simplify(l)
+	c := env.simplify(l)
 	iter := ListIterator{List: c, Env: env}
 	assert.True(t, iter.Next())
 	assert.Equal(t, NewAtom("a"), iter.Current())

--- a/interpreter.go
+++ b/interpreter.go
@@ -150,6 +150,7 @@ func (i *Interpreter) QueryContext(ctx context.Context, query string, args ...in
 	more := make(chan bool, 1)
 	next := make(chan *engine.Env)
 	sols := Solutions{
+		vm:   &i.VM,
 		vars: p.Vars,
 		more: more,
 		next: next,


### PR DESCRIPTION
`TermString` simplifies not only `1pl` but also the use case like https://github.com/ichiban/prolog/issues/270