### PR TITLE
Fix query unrecoverable panic

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -199,6 +199,12 @@ func (i *Interpreter) QueryContext(ctx context.Context, query string, args ...in
 
 	go func() {
 		defer close(next)
+		defer func() {
+			if r := recover(); r != nil {
+				sols.panicked = r
+			}
+		}()
+
 		if !<-more {
 			return
 		}

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -826,6 +826,20 @@ foo(a, 1, 2.0, [abc, def]).
 	}
 }
 
+func TestInterpreter_Query_panic(t *testing.T) {
+	var i Interpreter
+	i.Register0(engine.NewAtom("do_not_call"), func(_ *engine.VM, k engine.Cont, env *engine.Env) *engine.Promise {
+		panic("told you")
+	})
+
+	sols, err := i.Query("do_not_call.")
+	assert.NoError(t, err)
+	assert.PanicsWithValue(t, "told you", func() {
+		sols.Next()
+	})
+	assert.NoError(t, sols.Close())
+}
+
 func TestInterpreter_Query_close(t *testing.T) {
 	var i Interpreter
 	i.Register0(engine.NewAtom("do_not_call"), func(_ *engine.VM, k engine.Cont, env *engine.Env) *engine.Promise {

--- a/solutions.go
+++ b/solutions.go
@@ -18,13 +18,14 @@ var errConversion = errors.New("conversion failed")
 // Solutions is the result of a query. Everytime the Next method is called, it searches for the next solution.
 // By calling the Scan method, you can retrieve the content of the solution.
 type Solutions struct {
-	vm     *engine.VM
-	env    *engine.Env
-	vars   []engine.ParsedVariable
-	more   chan<- bool
-	next   <-chan *engine.Env
-	err    error
-	closed bool
+	vm       *engine.VM
+	env      *engine.Env
+	vars     []engine.ParsedVariable
+	more     chan<- bool
+	panicked any
+	next     <-chan *engine.Env
+	err      error
+	closed   bool
 }
 
 // Close closes the Solutions and terminates the search for other solutions.
@@ -46,6 +47,11 @@ func (s *Solutions) Next() bool {
 	s.more <- true
 	var ok bool
 	s.env, ok = <-s.next
+
+	if s.panicked != nil {
+		panic(s.panicked)
+	}
+
 	return ok
 }
 


### PR DESCRIPTION
## Issue description

When calling `Interpreter.QueryContext(...)` the prolog query is executed in another goroutine, as this is a different goroutine than the caller's one, if a panic occurs executing the query (i.e. typically executing a predicate) we can't recover from the caller's goroutine.

## Proposed solution

The proposed fix moves the panic occurring in the querying goroutine to the `Solutions.Next()` call to allow the caller to recover.

The implementation simply recover any panic in the querying goroutine, sets the recovered error value to the `Solutions` structure to propagate the panic in the `Next()` method, if any.

## Remarks

I tried to find the least invasive way possible, but I may not have seen the consequences of that choice, either in design or implementation. Please let me know if you have a more elegant way to handle this, I'd be happy to discuss it.

Thanks!