### PR TITLE
recover panic to promise

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -35,7 +35,8 @@ func Negate(vm *VM, goal Term, k Cont, env *Env) *Promise {
 }
 
 // Call executes goal. it succeeds if goal followed by k succeeds. A cut inside goal doesn't affect outside of Call.
-func Call(vm *VM, goal Term, k Cont, env *Env) *Promise {
+func Call(vm *VM, goal Term, k Cont, env *Env) (promise *Promise) {
+	defer ensurePromise(&promise)
 	switch g := env.Resolve(goal).(type) {
 	case Variable:
 		return Error(InstantiationError(env))

--- a/engine/builtin_test.go
+++ b/engine/builtin_test.go
@@ -22,6 +22,14 @@ func TestCall(t *testing.T) {
 	vm.Register0(atomFail, func(_ *VM, f Cont, env *Env) *Promise {
 		return Bool(false)
 	})
+	vm.Register0(NewAtom("do_not_call"), func(*VM, Cont, *Env) *Promise {
+		panic("told you")
+	})
+	vm.Register0(NewAtom("lazy_do_not_call"), func(*VM, Cont, *Env) *Promise {
+		return Delay(func(context.Context) *Promise {
+			panic("told you")
+		})
+	})
 	assert.NoError(t, vm.Compile(context.Background(), `
 foo.
 foo(_, _).
@@ -49,6 +57,8 @@ f(g([a, [b, c|X]])).
 
 		{title: `cover all`, goal: atomComma.Apply(atomCut, NewAtom("f").Apply(NewAtom("g").Apply(List(NewAtom("a"), PartialList(NewVariable(), NewAtom("b"), NewAtom("c")))))), ok: true},
 		{title: `out of memory`, goal: NewAtom("foo").Apply(NewVariable(), NewVariable(), NewVariable(), NewVariable(), NewVariable(), NewVariable(), NewVariable(), NewVariable(), NewVariable()), err: resourceError(resourceMemory, nil), mem: 1},
+		{title: `panic`, goal: NewAtom("do_not_call"), err: errors.New("panic: told you")},
+		{title: `panic (lazy)`, goal: NewAtom("lazy_do_not_call"), err: errors.New("panic: told you")},
 	}
 
 	for _, tt := range tests {

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -169,7 +169,9 @@ type procedure interface {
 type Cont func(*Env) *Promise
 
 // Arrive is the entry point of the VM.
-func (vm *VM) Arrive(name Atom, args []Term, k Cont, env *Env) *Promise {
+func (vm *VM) Arrive(name Atom, args []Term, k Cont, env *Env) (promise *Promise) {
+	defer ensurePromise(&promise)
+
 	if vm.Unknown == nil {
 		vm.Unknown = func(Atom, []Term, *Env) {}
 	}


### PR DESCRIPTION
An alternative solution for https://github.com/ichiban/prolog/pull/288

While #288 makes an interpreter transparent to panics, this PR makes it eagerly convert panics to Prolog exceptions.