### PR TITLE
Enable Consult to be operated from external package, and test that pr…

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -674,7 +675,24 @@ func Assertz(vm *VM, t Term, k Cont, env *Env) *Promise {
 	}, env); err != nil {
 		return Error(err)
 	}
+	saveToRaw(vm, t, "assertz")
 	return k(env)
+}
+
+// saveToRaw - saves a copy of the predicate to the rawText in the VM so that it can be exported later - if required.
+func saveToRaw(vm *VM, t Term, rawkey string) {
+	var buf bytes.Buffer
+	opts := WriteOptions{}
+	t.WriteTerm(&buf, &opts, nil)
+	if vm.rawtext == nil {
+		vm.rawtext = make(map[string]string)
+	}
+	if vm.rawtext["asserta"] == "" {
+		vm.rawtext["asserta"] = fmt.Sprintf("%s\n", buf.String())
+	} else {
+		vm.rawtext["asserta"] = fmt.Sprintf("%s%s\n", vm.rawtext["asserta"], buf.String())
+	}
+
 }
 
 // Asserta prepends t to the database.
@@ -684,6 +702,7 @@ func Asserta(vm *VM, t Term, k Cont, env *Env) *Promise {
 	}, env); err != nil {
 		return Error(err)
 	}
+	saveToRaw(vm, t, "asserta")
 	return k(env)
 }
 

--- a/engine/text_test.go
+++ b/engine/text_test.go
@@ -467,7 +467,7 @@ func TestVM_Consult(t *testing.T) {
 		{title: `:- consult([]).`, files: List(), ok: true},
 		{title: `:- consult(['testdata/empty.txt']).`, files: List(NewAtom("testdata/empty.txt")), ok: true},
 		{title: `:- consult(['testdata/empty.txt', 'testdata/empty.txt']).`, files: List(NewAtom("testdata/empty.txt"), NewAtom("testdata/empty.txt")), ok: true},
-
+		{title: `:- consult(['testdata/break_term_expansion.pl']).`, files: List(NewAtom("testdata/break_term_expansion.pl")), ok: true},
 		{title: `:- consult('testdata/abc.txt').`, files: NewAtom("testdata/abc.txt"), err: io.EOF},
 		{title: `:- consult(['testdata/abc.txt']).`, files: List(NewAtom("testdata/abc.txt")), err: io.EOF},
 

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -68,7 +68,8 @@ type VM struct {
 	// I/O
 	streams       streams
 	input, output *Stream
-
+	// raw text
+	rawtext map[string]string
 	// Misc
 	debug bool
 }
@@ -300,6 +301,15 @@ func (vm *VM) SetUserOutput(s *Stream) {
 	s.alias = atomUserOutput
 	vm.streams.add(s)
 	vm.output = s
+}
+
+func (vm *VM) SetPrologOperators() {
+	vm.operators.define(1200, operatorSpecifierXFX, atomIf)
+	vm.operators.define(1200, operatorSpecifierXFX, atomArrow)
+	vm.operators.define(1200, operatorSpecifierFX, atomIf)
+	vm.operators.define(1000, operatorSpecifierXFY, atomComma)
+	vm.operators.define(400, operatorSpecifierYFX, atomSlash)
+	return
 }
 
 // Predicate0 is a predicate of arity 0.


### PR DESCRIPTION
…edicate/rule can be consulted

Without operators the Consult function can't be called and correctly completed from an external package. The existing tests add the operators manually before calling consult. But the tests in text_test.go rely on the fact they are in the "engine" package. The SetPrologOperators is a - potentially expandable - set of default operators needed to Consult prolog files.

The rawtext map added to the VM structure is a placeholder for the next pull request (about saving files).