### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ### Install latest version
 
 ```console
-go get -u github.com/ichiban/prolog
+go install github.com/ichiban/prolog@latest
 ```
 
 ### Usage


### PR DESCRIPTION
Change of Go . Go get is no longer supported outside a module. Use go install. go install github.com/ichiban/prolog@latest