### PR TITLE
fix end_of_stream detection

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -1266,6 +1266,7 @@ func Open(vm *VM, sourceSink, mode, stream, options Term, k Cont, env *Env) *Pro
 	case err == nil:
 		if s.mode == ioModeRead {
 			s.source = f
+			s.initRead()
 		} else {
 			s.sink = f
 		}
@@ -1288,12 +1289,6 @@ func Open(vm *VM, sourceSink, mode, stream, options Term, k Cont, env *Env) *Pro
 	}
 	if err := iter.Err(); err != nil {
 		return Error(err)
-	}
-
-	if s.mode == ioModeRead {
-		if err := s.initRead(); err == nil {
-			s.checkEOS()
-		}
 	}
 
 	return Unify(vm, stream, &s, k, env)

--- a/engine/builtin_test.go
+++ b/engine/builtin_test.go
@@ -3295,6 +3295,7 @@ func TestOpen(t *testing.T) {
 				assert.True(t, ok)
 				assert.Equal(t, l, s)
 
+				assert.NoError(t, s.initRead())
 				b, err := io.ReadAll(s.buf)
 				assert.NoError(t, err)
 				assert.Equal(t, "test\n", string(b))
@@ -4767,7 +4768,7 @@ func TestGetByte(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var m mockReader
-		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Twice()
+		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Once()
 		defer m.AssertExpectations(t)
 
 		s := &Stream{source: &m, mode: ioModeRead, streamType: streamTypeBinary}
@@ -4925,7 +4926,7 @@ func TestGetChar(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var m mockReader
-		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Times(2)
+		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Once()
 		defer m.AssertExpectations(t)
 
 		v := NewVariable()
@@ -5095,7 +5096,7 @@ func TestPeekByte(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var m mockReader
-		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Twice()
+		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Once()
 		defer m.AssertExpectations(t)
 
 		s := &Stream{source: &m, mode: ioModeRead}
@@ -5255,7 +5256,7 @@ func TestPeekChar(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		var m mockReader
-		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Twice()
+		m.On("Read", mock.Anything).Return(0, errors.New("failed")).Once()
 		defer m.AssertExpectations(t)
 
 		v := NewVariable()

--- a/engine/text_test.go
+++ b/engine/text_test.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"errors"
 	"io"
+	"io/fs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,14 @@ import (
 
 //go:embed testdata
 var testdata embed.FS
+
+func mustOpen(fs fs.FS, name string) fs.File {
+	f, err := fs.Open(name)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
 
 func TestVM_Compile(t *testing.T) {
 	tests := []struct {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -229,6 +229,7 @@ func TestNew_variableNames(t *testing.T) {
 		output   string
 		outputFn func(t *testing.T, output string)
 		err      error
+		waits    bool
 	}{
 		{name: "1", query: `catch(write_term(T,[quoted(true), variable_names([N=T])]), error(instantiation_error, _), true).`},
 		{name: "2", query: `N = 'X', write_term(T,[quoted(true), variable_names([N=T])]).`, output: `X`},
@@ -269,7 +270,7 @@ func TestNew_variableNames(t *testing.T) {
 		}},
 		{name: "26", query: `T=(X,Y,Z), write_term(T,[quoted(true), variable_names(['X'=Z,'X'=Y,'X'=X])]).`, output: `X,X,X`},
 		{name: "27", query: `T=(1,2,3), T=(X,Y,Z), write_term(T,[quoted(true), variable_names(['X'=Z,'X'=Y,'X'=X])]).`, output: `1,2,3`},
-		{name: "32", query: `read_term(T,[variable_names(VN_list)]), VN_list=[_=1,_=2,_=3], writeq(VN_list).`, err: context.DeadlineExceeded},
+		{name: "32", query: `read_term(T,[variable_names(VN_list)]), VN_list=[_=1,_=2,_=3], writeq(VN_list).`, err: context.DeadlineExceeded, waits: true},
 		{name: "29", input: `B+C+A+B+C+A.`, query: `read_term(T,[variable_names(VN_list)]), VN_list=[_=1,_=2,_=3], writeq(VN_list).`, output: `['B'=1,'C'=2,'A'=3]`},
 		{name: "30", query: `catch(write_term(T, [variable_names(VN_list)]), error(instantiation_error, _), true).`},
 		{name: "31", query: `catch((VN_list = 1, write_term(T, [variable_names(VN_list)])), error(domain_error(write_option, variable_names(_)), _), true).`},
@@ -297,9 +298,9 @@ func TestNew_variableNames(t *testing.T) {
 		{name: "60", query: `catch((O = alias(_), open(f,write,_,[O])), error(instantiation_error, _), true).`},
 		{name: "42", query: `catch((O = type(nontype), open(f,write,_,[O])), error(domain_error(stream_option, type(nontype)), _), true).`},
 		{name: "61", query: `catch((O = alias(1), open(f,write,_,[O])), error(domain_error(stream_option, alias(1)), _), true).`},
-		{name: "45", query: `read_term(T,[variable_names(VN_list)]).`, err: context.DeadlineExceeded},
+		{name: "45", query: `read_term(T,[variable_names(VN_list)]).`, waits: true},
 		{name: "46", input: `a.`, query: `read_term(T,[variable_names(VN_list)]), T = a, VN_list = [].`},
-		{name: "47", query: `VN_list = 42, read_term(T,[variable_names(VN_list)]).`, err: context.DeadlineExceeded},
+		{name: "47", query: `VN_list = 42, read_term(T,[variable_names(VN_list)]).`, waits: true},
 		{name: "48", input: `a.`, query: `VN_list = 42, \+read_term(T,[variable_names(VN_list)]).`},
 		{name: "49", input: `a b.`, query: `VN_list = 42, catch(read_term(T,[variable_names(VN_list)]), error(syntax_error(_), _), true).`},
 		{name: "53", query: `catch(write_term(S,[quoted(true), variable_names([N=T])]), error(instantiation_error, _), true).`},
@@ -307,7 +308,7 @@ func TestNew_variableNames(t *testing.T) {
 		{name: "55", query: `S=1+T,N=' /*r*/V',write_term(S,[quoted(true), variable_names([N=T])]).`, output: `1+ /*r*/V`},
 		{name: "58", query: `S=1+T,N=(+),write_term(S,[quoted(true), variable_names([N=T])]).`, output: `1++`},
 		{name: "59", query: `S=T+1,N=(+),write_term(S,[quoted(true), variable_names([N=T])]).`, output: `++1`},
-		{name: "69", query: `read_term(T, [singletons(1)]).`, err: context.DeadlineExceeded},
+		{name: "69", query: `read_term(T, [singletons(1)]).`, waits: true},
 		{name: "70", input: `a.`, query: `\+read_term(T, [singletons(1)]).`},
 	}
 
@@ -331,6 +332,7 @@ func TestNew_variableNames(t *testing.T) {
 			} else {
 				tt.outputFn(t, out.String())
 			}
+			assert.Equal(t, tt.waits, errors.Is(ctx.Err(), context.DeadlineExceeded))
 		})
 	}
 }


### PR DESCRIPTION
https://github.com/ichiban/prolog/issues/300

peek() based detection requires extra bytes from the io.Reader. Use buffered bytes and file sizes instead.