### PR TITLE
Remove unused 'loaded' field from interpreter struct

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -17,7 +17,6 @@ var bootstrap string
 // Interpreter is a Prolog interpreter. The zero value is a valid interpreter without any predicates/operators defined.
 type Interpreter struct {
 	engine.VM
-	loaded map[string]struct{}
 }
 
 // New creates a new Prolog interpreter with predefined predicates/operators.


### PR DESCRIPTION
Minor. The removed field is part of the embedded VM struct, as far as I can see. 